### PR TITLE
Bench with leveldb and and litedb

### DIFF
--- a/DBTrie.Bench/BenchmarkDatabases.cs
+++ b/DBTrie.Bench/BenchmarkDatabases.cs
@@ -1,0 +1,179 @@
+﻿using BenchmarkDotNet.Attributes;
+using DBTrie.Storage;
+using DBTrie.Tests;
+using DBTrie.TrieModel;
+using LevelDB;
+using LiteDB;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DBTrie.Bench
+{
+    [MarkdownExporterAttribute.GitHub]
+    [RankColumn, MemoryDiagnoser]
+    public class BenchmarkDatabases
+    {
+        private string folder;
+        private DBTrieEngine trie;
+        private DB ldb;
+        private LiteDatabase litedb;
+        private ILiteCollection<LiteDbEntity> litedbCol;
+
+        private int trieInsertCount = 0;
+        private int ldbInsertCount = 0;
+        private int litedbInsertCount = 0;
+        private int trieGetCount = 0;
+        private int ldbGetCount = 0;
+        private int litedbGetCount = 0;
+        private int trieDeleteCount = 0;
+        private int ldbDeleteCount = 0;
+        private int litedbDeleteCount = 0;
+
+        private byte[] data = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            folder = @"C:\BenchData";
+            Directory.CreateDirectory($@"{folder}\trie");
+            trie = DBTrieEngine.OpenFromFolder($@"{folder}\trie").Result;
+            ldb = new DB(new Options { CreateIfMissing = true }, $@"{folder}\ldb");
+            Directory.CreateDirectory($@"{folder}\litedb");
+            litedb = new LiteDatabase(new ConnectionString() { Filename = $@"{folder}\litedb\db" });
+            this.litedbCol = litedb.GetCollection<LiteDbEntity>("tbl");
+        }
+
+        [GlobalCleanup]
+        public async Task Cleanup()
+        {
+            await trie.DisposeAsync();
+            ldb.Dispose();
+            litedb.Dispose();
+        }
+
+        [Benchmark]
+        public async Task TrieInsert()
+        {
+            using (var trx = await trie.OpenTransaction())
+            {
+                var tbl = trx.GetTable("tbl");
+                for (int i = 0; i < 10; i++)
+                {
+                    await tbl.Insert(BitConverter.GetBytes(trieInsertCount++), data);
+                }
+
+                await tbl.Commit();
+            }
+        }
+
+        [Benchmark]
+        public void LeveldbInsert()
+        {
+            using (var batch = new WriteBatch())
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    batch.Put(new byte[] { 1 }.Concat(BitConverter.GetBytes(ldbInsertCount++)).ToArray(), data);
+                }
+
+                ldb.Write(batch);
+            }
+        }
+
+        [Benchmark]
+        public void LitedbInsert()
+        {
+            var list = new List<LiteDbEntity>();
+
+            for (int i = 0; i < 10; i++)
+            {
+                list.Add(new LiteDbEntity { Table = 1, Key = BitConverter.GetBytes(litedbInsertCount++), Value = data });
+            }
+
+            litedbCol.InsertBulk(list);
+        }
+
+        [Benchmark]
+        public async Task TrieGet()
+        {
+            using (var trx = await trie.OpenTransaction())
+            {
+                var tbl = trx.GetTable("tbl");
+                for (int i = 0; i < 10; i++)
+                {
+                    await tbl.Get(BitConverter.GetBytes(trieGetCount++));
+                }
+            }
+        }
+
+        [Benchmark]
+        public void LeveldbGet()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                ldb.Get(new byte[] { 1 }.Concat(BitConverter.GetBytes(ldbGetCount++)).ToArray());
+            }
+        }
+
+        [Benchmark]
+        public void LitedbGet()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                litedbCol.FindById(BitConverter.GetBytes(litedbGetCount++));
+            }
+        }
+
+        [Benchmark]
+        public async Task TrieDelete()
+        {
+            using (var trx = await trie.OpenTransaction())
+            {
+                var tbl = trx.GetTable("tbl");
+                for (int i = 0; i < 10; i++)
+                {
+                    await tbl.Delete(BitConverter.GetBytes(trieDeleteCount++));
+                }
+
+                await tbl.Commit();
+            }
+        }
+
+        [Benchmark]
+        public void LeveldbDelete()
+        {
+            using (var batch = new WriteBatch())
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    batch.Delete(new byte[] { 1 }.Concat(BitConverter.GetBytes(ldbDeleteCount++)).ToArray());
+                }
+
+                ldb.Write(batch);
+            }
+        }
+
+        [Benchmark]
+        public void LitedbDelete()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                litedbCol.Delete(BitConverter.GetBytes(litedbDeleteCount++));
+            }
+        }
+    }
+
+    public class LiteDbEntity
+    {
+        public int Table { get; set; }
+
+        [BsonId]
+        public byte[] Key { get; set; }
+
+        public byte[] Value { get; set; }
+    }
+}

--- a/DBTrie.Bench/DBTrie.Bench.csproj
+++ b/DBTrie.Bench/DBTrie.Bench.csproj
@@ -7,6 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="LevelDB.Standard" Version="2.1.6.1" />
+    <PackageReference Include="LiteDB" Version="5.0.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### I crated this benchmark with leveldb and litedb for bulk insert/get/delete



BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.388 (2004/?/20H1)
Intel Core i9-9980HK CPU 2.40GHz, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.300
  [Host] : .NET Core 3.1.4 (CoreCLR 4.700.20.20201, CoreFX 4.700.20.22101), X64 RyuJIT

Toolchain=InProcessEmitToolchain  

|        Method |        Mean |      Error |     StdDev |      Median | Rank |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------------- |------------:|-----------:|-----------:|------------:|-----:|--------:|-------:|------:|----------:|
|    TrieInsert |   649.89 μs |  36.498 μs | 106.468 μs |   647.98 μs |    6 | 21.4844 | 0.9766 |     - |  175.6 KB |
| LeveldbInsert |    32.44 μs |   6.579 μs |  19.087 μs |    20.19 μs |    1 |  0.2441 | 0.0305 |     - |    2.1 KB |
|  LitedbInsert |   904.96 μs |  30.994 μs |  88.426 μs |   883.00 μs |    7 | 19.5313 | 3.9063 |     - | 180.47 KB |
|       TrieGet |   346.76 μs |  11.165 μs |  32.569 μs |   344.34 μs |    3 | 19.5313 | 0.9766 |     - | 161.38 KB |
|    LeveldbGet |    74.62 μs |   3.024 μs |   8.226 μs |    72.94 μs |    2 |  0.2441 |      - |     - |   2.73 KB |
|     LitedbGet |   541.50 μs |  11.647 μs |  33.604 μs |   532.51 μs |    5 | 48.8281 | 1.9531 |     - | 404.27 KB |
|    TrieDelete |   505.52 μs |  52.140 μs | 153.736 μs |   418.77 μs |    4 |  7.8125 |      - |     - |  67.32 KB |
| LeveldbDelete |    32.51 μs |   4.608 μs |  13.588 μs |    33.08 μs |    1 |  0.2441 | 0.0610 |     - |    2.1 KB |
|  LitedbDelete | 2,464.34 μs | 111.322 μs | 297.142 μs | 2,489.66 μs |    8 |  7.8125 |      - |     - |  68.29 KB |

*Legends*
  Mean      : Arithmetic mean of all measurements
  Error     : Half of 99.9% confidence interval
  StdDev    : Standard deviation of all measurements
  Median    : Value separating the higher half of all measurements (50th percentile)
  Rank      : Relative position of current benchmark mean among all benchmarks (Arabic style)
  Gen 0     : GC Generation 0 collects per 1000 operations
  Gen 1     : GC Generation 1 collects per 1000 operations
  Gen 2     : GC Generation 2 collects per 1000 operations
  Allocated : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
  1 μs      : 1 Microsecond (0.000001 sec)